### PR TITLE
revert: compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@
  */
 
 function trimEnd(str) {
-  let lastCharPos = str.length - 1;
-  let lastChar = str[lastCharPos];
+  var lastCharPos = str.length - 1;
+  var lastChar = str[lastCharPos];
   while(lastChar === ' ' || lastChar === '\t') {
     lastChar = str[--lastCharPos];
   }


### PR DESCRIPTION
In commit 9f626935f3fac6ec0f3c4b26baea4eb9740d9645, `let` was used.
https://github.com/aashutoshrathi/word-wrap/blob/9f626935f3fac6ec0f3c4b26baea4eb9740d9645/index.js#L9-L10

However, the `package.json` specifies `"node": ">=0.10.0"` compatibility.
https://github.com/aashutoshrathi/word-wrap/blob/9f626935f3fac6ec0f3c4b26baea4eb9740d9645/package.json#L28

This resulted in the following errors for older Node.js:
```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Thus, we should change `let` to `var` to maintain compatibility for `^1.x.x` in adherence to semver.
If compatibility needs to be upgraded, it should be the next major semver (`^2.x.x`) release.